### PR TITLE
Default mission assignment

### DIFF
--- a/betterContracts.lua
+++ b/betterContracts.lua
@@ -132,6 +132,12 @@ function BetterContracts:initialize()
     addMapping("roll", SC.SIMPLE) 				-- roller mission by tn4799
     addMapping("lime", SC.SPREAD) 				-- lime mission by Mmtrx
 
+	for _, missionType in pairs(g_missionManager.missionTypes) do
+		if self.typeToCat[missionType.type] == nil then
+			addMapping(missionType.name, SC.OTHER) -- default category for not registered mission types
+		end
+	end
+
 	self.harvest = {} -- harvest missions       	1
 	self.spread = {} -- sow, spray, fertilize, lime 2
 	self.simple = {} -- plow, cultivate, weed   	3

--- a/missionVehicles/baseGame.xml
+++ b/missionVehicles/baseGame.xml
@@ -2,7 +2,7 @@
 <!--=====================================================================================================
     BetterContracts mission vehicles additions
     Purpose:    Enhance ingame contracts with extra loan vehicle sets
-    Author:     Mmtrx       
+    Author:     Mmtrx
     Limitation: no entries for cotton/ sugarcane harvest, sugarBeet/ cotton/ sugarcane
                 sowing, and mow-bale for small/ medium fields
     Changelog:
@@ -12,7 +12,8 @@
 
 ======================================================================================================-->
 <missionVehicles overwrite="false">
- 
+    <variants/>
+
     <mission type="harvest" >
         <!-- grainMission -->
         <group fieldSize="small" variant="GRAIN" rewardScale="1.2">
@@ -490,7 +491,7 @@
                 <configuration name="wheel" id="4" />
             </vehicle>
             <vehicle filename="$data/vehicles/amazone/zgts10001/zgts10001.xml"/> <!-- spreader -->
-            <vehicle filename="$data/vehicles/agco/weight1100/weight1100.xml" /> 
+            <vehicle filename="$data/vehicles/agco/weight1100/weight1100.xml" />
         </group>
         <group fieldSize="medium" rewardScale="1.5">
             <vehicle filename="$data/vehicles/deutzFahr/series8/series8.xml">
@@ -549,7 +550,7 @@
         </group>
         <group fieldSize="large">
             <vehicle filename="$data/vehicles/newHolland/t9/t9.xml" /> <!-- tractor -->
-            <vehicle filename="$data/vehicles/vaderstad/nzExtreme1425/nzExtreme1425.xml" /> 
+            <vehicle filename="$data/vehicles/vaderstad/nzExtreme1425/nzExtreme1425.xml" />
         </group>
     </mission>
 


### PR DESCRIPTION
I've implemented that each mission type gets assigned to a Category. This should prevent the problem when new missionTypes get added to the game with mods that the game doesn't load in combination with better contracts. 
I know, the default category sometimes will not fit by default but this could then be manually changed with an update. 